### PR TITLE
Added exclude flag to allow filtering packages from the list of dependencis

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@ Usage is like:
 ::
 
     usage: poet [-h] [--single package [package ...] | --formula package |
-                      --resources package]
+                --resources package] [-V] [--exclude [package [package ...]]]
 
     Generate Homebrew resource stanzas for pypi packages and their dependencies.
 
@@ -44,6 +44,10 @@ Usage is like:
       --resources package, -r package
                             Generate resource stanzas for a package and its
                             recursive dependencies (default).
+      -V, --version         show program's version number and exit
+      --exclude [package [package ...]], -e [package [package ...]]
+                            Exclude one or more packages but not its recursive
+                            dependencies.
 
 License
 -------

--- a/poet/poet.py
+++ b/poet/poet.py
@@ -181,6 +181,11 @@ def formula_for(package):
         root = nodes[package]
     elif package.lower() in nodes:
         root = nodes[package.lower()]
+    elif package in excludes:
+        root = {'name': package,
+                'homepage': 'http://example.com/your_package_homepage',
+                'url': 'http://pypi.example.com/your_package_url',
+                'checksum': 'Insert SHA256 here'}
     else:
         raise "Could not find package {} in nodes {}".format(package, nodes.keys())
 
@@ -191,8 +196,8 @@ def formula_for(package):
                                    ResourceTemplate=RESOURCE_TEMPLATE)
 
 
-def resources_for(package):
-    nodes = make_graph(package)
+def resources_for(package, excludes):
+    nodes = make_graph(package, excludes)
     return '\n\n'.join([RESOURCE_TEMPLATE.render(resource=node)
                         for node in nodes.values()])
 
@@ -226,8 +231,14 @@ def main():
         parser.print_usage(sys.stderr)
         return 1
 
+    if (args.exclude and args.single):
+        print('--singel/-s not allowed with argument --exclude/-e',
+              file=sys.stderr)
+        parser.print_usage(sys.stderr)
+        return 1
+
     if args.formula:
-        print(formula_for(args.formula))
+        print(formula_for(args.formula, args.exclude))
     elif args.single:
         for i, package in enumerate(args.single):
             data = research_package(package)
@@ -239,7 +250,7 @@ def main():
         if not package:
             parser.print_usage(sys.stderr)
             return 1
-        print(resources_for(package))
+        print(resources_for(package, args.exclude))
     return 0
 
 


### PR DESCRIPTION
This adds `--exclude` flag to allow one to skip dependencies not available in PyPi.

1) Added a some error handling printing which package failed:

``` shell
$ poet -r priv
Error getting information about priv from pypi.python.org: HTTP Error 404: Not Found
Traceback (most recent call last):
  File "/Users/rickardvonessen/Library/Python/2.7/bin/poet", line 9, in <module>
    load_entry_point('homebrew-pypi-poet==0.6.1.dev0', 'console_scripts', 'poet')()
  File "/Users/rickardvonessen/src/homebrew-pypi-poet/poet/poet.py", line 244, in main
    print(resources_for(package, args.exclude))
  File "/Users/rickardvonessen/src/homebrew-pypi-poet/poet/poet.py", line 189, in resources_for
    nodes = make_graph(package, excludes)
  File "/Users/rickardvonessen/src/homebrew-pypi-poet/poet/poet.py", line 155, in make_graph
    package_data = research_package(package, dependencies[package]['version'])
  File "/Users/rickardvonessen/src/homebrew-pypi-poet/poet/poet.py", line 133, in research_package
    raise e
urllib2.HTTPError: HTTP Error 404: Not Found
```

2) Create filtered resource stanza: 

``` shell
$ poet -e priv versioneer -r priv
  resource "boto3" do
    url "https://pypi.python.org/packages/d9/6c/1063a4984d13f1b22edb30f3b97b6df7e0bdc7792ebc2f638b31f8b2ff79/boto3-1.3.1.tar.gz"
    sha256 "6e4d33f2935580278af84b8d63760306d9586a5144780e4ba37737a1f2bdc56f"
  end

  resource "botocore" do
    url "https://pypi.python.org/packages/a1/c8/318182159de910f9043a625200955fbacec450da7091879a7ea262575b4e/botocore-1.4.21.tar.gz"
    sha256 "47997874a466e3ccd993e35cabbf55518a719f5fa0df69992d956f93b0d81738"
  end
```

3) When you create filtered formula and filter on the root you will get some dummy values to replace manually:

``` shell
$ poet -e priv versioneer -f priv
class Priv < Formula
  homepage "http://example.com/your_package_homepage"
  url "http://pypi.example.com/your_package_url"
  sha256 "Insert SHA256 here"

  depends_on :python if MacOS.version <= :snow_leopard

  resource "boto3" do
    url "https://pypi.python.org/packages/d9/6c/1063a4984d13f1b22edb30f3b97b6df7e0bdc7792ebc2f638b31f8b2ff79/boto3-1.3.1.tar.gz"
    sha256 "6e4d33f2935580278af84b8d63760306d9586a5144780e4ba37737a1f2bdc56f"
  end

  resource "botocore" do
    url "https://pypi.python.org/packages/a1/c8/318182159de910f9043a625200955fbacec450da7091879a7ea262575b4e/botocore-1.4.21.tar.gz"
    sha256 "47997874a466e3ccd993e35cabbf55518a719f5fa0df69992d956f93b0d81738"
  end


  def install
    ENV.prepend_create_path "PYTHONPATH", libexec/"vendor/lib/python2.7/site-packages"
    %w[boto3 botocore].each do |r|
      resource(r).stage do
        system "python", *Language::Python.setup_install_args(libexec/"vendor")
      end
    end

    ENV.prepend_create_path "PYTHONPATH", libexec/"lib/python2.7/site-packages"
    system "python", *Language::Python.setup_install_args(libexec)

    bin.install Dir[libexec/"bin/*"]
    bin.env_script_all_files(libexec/"bin", :PYTHONPATH => ENV["PYTHONPATH"])
  end
end
```

4) Creating a resource stanza can't take `--exclude`:

``` shell
$ poet -e priv -s priv
--singel/-s not allowed with argument --exclude/-e
usage: poet [-h] [--single package [package ...] | --formula package |
            --resources package] [-V] [--exclude [package [package ...]]]
```
