### PR TITLE
Do not use prerelease versions of packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.4'
     ],
-    install_requires=['jinja2', 'setuptools'],
+    install_requires=['jinja2', 'pip', 'setuptools'],
     entry_points={'console_scripts': [
         'poet=poet:main',
         'poet_lint=poet.lint:main',


### PR DESCRIPTION
The `pypi.org/pypi/{package}/json` (or `pypi.python.org/pypi/{package}/json`) API returns all versions of a package, including prerelease versions; in particular, the default (`.urls` in the JSON payload) could be prerelease. Using `.urls` in the JSON payload by default (which currently means any package that is not a parsed dependency) results in the possibility of generated resources being a prerelease version, which is undesirable for Homebrew most of the time. For instance, prior to this commit, `poet -s wheel` or `poet -r wheel` would generate

```rb
  resource "wheel" do
    url "https://files.pythonhosted.org/packages/a7/37/947b4329c4a3c72093b6c8e9b4be8c7f10c32dbb78848d3a234ce01c059d/wheel-0.30.0a0.tar.gz"
    sha256 "98f3e09b4ad7f5649a7e3d00e0e005ec1824ddcd6ec16c5086c05b1d91ada6da"
  end
```

This commit switches to `pip.index.PackageFinder`, which automatically excludes prereleases unless `allow_all_prereleases` is set to True, and obviously better reflects what pip would actually install.

The known only "regression" is the inability of retrieving package homepage via this method, but since it's only ever used in `poet -f`, it shouldn't be a big problem for package authors, who should be aware of the package homepage anyway.

The other concern is that pip doesn't have a stable API officially, but the basic components being used here at least dates back to 6.0 from Dec 2014.

---

Alternatively, we can manually sort all versions returned by the `pypi.org/pypi/{package}/json` API and drop the prerelease versions.