### PR TITLE
Fix tests in light of current Brew specification

### DIFF
--- a/poet/templates.py
+++ b/poet/templates.py
@@ -18,7 +18,7 @@ FORMULA_TEMPLATE = env.from_string(dedent("""\
       url "{{ package.url }}"
       sha256 "{{ package.checksum }}"
 
-      depends_on :{{ python }}
+      depends_on "{{ python }}"
 
     {% if resources %}
     {%   for resource in resources %}

--- a/poet/test/test_poet.py
+++ b/poet/test/test_poet.py
@@ -24,9 +24,9 @@ def test_formula():
     result = poet("-f", "pytest")
     assert b'resource "py" do' in result
     if sys.version_info.major == 2:
-        assert b'depends_on :python' in result
+        assert b'depends_on "python"' in result
     else:
-        assert b'depends_on :python3' in result
+        assert b'depends_on "python3"' in result
 
 
 def test_case_sensitivity():


### PR DESCRIPTION
Brew now specifies python dependencies with `"python"` or `"python3"`
rather than `:python` or `:python3` respectively.  The tests currently
fail on `master` because `brew` returns non-zero in the latter case.