### PR TITLE
Template updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ target/
 Session.vim
 .netrwhist
 *~
+
+# pytest
+.pytest_cache/

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,18 +2,18 @@ os: osx
 osx_image: xcode9.2
 language: generic
 branches:
-    only:
+  only:
     - master
     - /^v\d.*/
 env:
-- TOXENV=py2 PYTHON=python2
-- TOXENV=py2-flake8 PYTHON=python2
-- TOXENV=py3 PYTHON=python3
+- TOXENV=py2 PYTHON=python2 BREWPY=python@2
+- TOXENV=py2-flake8 PYTHON=python2 BREWPY=python@2
+- TOXENV=py3 PYTHON=python3 BREWPY=python
 
 before_install:
 - brew update
 install:
-- brew ls $PYTHON || brew install $PYTHON
+- brew ls $BREWPY || brew install $BREWPY
 - $PYTHON -m pip install tox coverage coveralls
 - if [ $PYTHON == "python2" ]; then ln -fs /usr/local/bin/python2 /usr/local/bin/python; ln -fs /usr/local/bin/pip2 /usr/local/bin/pip; fi
 - sudo mkdir -p /usr/local/man && sudo chown $USER /usr/local/man

--- a/poet/poet.py
+++ b/poet/poet.py
@@ -169,7 +169,7 @@ def formula_for(package, also=None):
     else:
         raise Exception("Could not find package {} in nodes {}".format(package, nodes.keys()))
 
-    python = "python" if sys.version_info.major == 2 else "python3"
+    python = "python@2" if sys.version_info.major == 2 else "python"
     return FORMULA_TEMPLATE.render(package=root,
                                    resources=resources,
                                    python=python,

--- a/poet/templates.py
+++ b/poet/templates.py
@@ -28,9 +28,6 @@ FORMULA_TEMPLATE = env.from_string(dedent("""\
     {%   endfor %}
     {% endif %}
       def install
-    {% if python == "python3" %}
-        virtualenv_create(libexec, "python3")
-    {% endif %}
         virtualenv_install_with_resources
       end
 

--- a/poet/test/test_poet.py
+++ b/poet/test/test_poet.py
@@ -24,9 +24,9 @@ def test_formula():
     result = poet("-f", "pytest")
     assert b'resource "py" do' in result
     if sys.version_info.major == 2:
-        assert b'depends_on "python"' in result
+        assert b'depends_on "python@2"' in result
     else:
-        assert b'depends_on "python3"' in result
+        assert b'depends_on "python"' in result
 
 
 def test_case_sensitivity():


### PR DESCRIPTION
* Use `python` and `python@2` dependencies as `python3` is deprecated
* Remove unneeded `virtualenv_create` (see: https://github.com/Homebrew/homebrew-core/pull/26164#issuecomment-378890270)