### PR TITLE
Added support for Pipfile.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ target/
 Session.vim
 .netrwhist
 *~
+
+# Obnoxious IDE Files
+.idea

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 os: osx
-osx_image: xcode9.2
+osx_image: xcode12.5
 language: generic
 branches:
     only:
@@ -10,8 +10,6 @@ env:
 - TOXENV=py2-flake8 PYTHON=python2
 - TOXENV=py3 PYTHON=python3
 
-before_install:
-- brew update
 install:
 - brew ls $PYTHON || brew install $PYTHON
 - $PYTHON -m pip install tox coverage coveralls

--- a/README.rst
+++ b/README.rst
@@ -51,6 +51,8 @@ Usage is like:
       --resources package, -r package
                             Generate resource stanzas for a package and its
                             recursive dependencies (default).
+      --lock path, -l path  Specify a path to a package containing a Pipfile.lock
+                            that you want to generate stanzas for.
       -V, --version         show program's version number and exit
 
 License

--- a/poet/poet.py
+++ b/poet/poet.py
@@ -260,8 +260,8 @@ def main():
         version='homebrew-pypi-poet {}'.format(__version__))
     args = parser.parse_args()
 
-    if args.path:
-        lock_file_data = get_lock_file_from_path(args.path)
+    if args.lock:
+        lock_file_data = get_lock_file_from_path(args.lock)
         print(from_lock(lock_file_data))
         return 1
 

--- a/poet/poet.py
+++ b/poet/poet.py
@@ -19,7 +19,6 @@ import logging
 import os
 import sys
 import warnings
-
 import pkg_resources
 
 from .templates import FORMULA_TEMPLATE, RESOURCE_TEMPLATE
@@ -80,9 +79,7 @@ def research_package(name, version=None):
     with closing(urlopen("https://pypi.io/pypi/{}/json".format(name))) as f:
         reader = codecs.getreader("utf-8")
         pkg_data = json.load(reader(f))
-    d = {}
-    d['name'] = pkg_data['info']['name']
-    d['homepage'] = pkg_data['info'].get('home_page', '')
+    d = {'name': pkg_data['info']['name'], 'homepage': pkg_data['info'].get('home_page', '')}
     artefact = None
     if version:
         for pypi_version in pkg_data['releases']:
@@ -178,8 +175,9 @@ def formula_for(package, also=None):
 
 def resources_for(packages):
     nodes = merge_graphs(make_graph(p) for p in packages)
-    return '\n\n'.join([RESOURCE_TEMPLATE.render(resource=node)
-                        for node in nodes.values()])
+    return '\n\n'.join(
+        RESOURCE_TEMPLATE.render(resource=node) for node in nodes.values()
+    )
 
 
 def merge_graphs(graphs):
@@ -188,9 +186,7 @@ def merge_graphs(graphs):
         for key in g:
             if key not in result:
                 result[key] = g[key]
-            elif result[key] == g[key]:
-                pass
-            else:
+            elif result[key] != g[key]:
                 warnings.warn(
                     "Merge conflict: {l.name} {l.version} and "
                     "{r.name} {r.version}; using the former.".
@@ -245,7 +241,7 @@ def main():
         for i, package in enumerate(args.single):
             data = research_package(package)
             print(RESOURCE_TEMPLATE.render(resource=data))
-            if i != len(args.single)-1:
+            if i != len(args.single) - 1:
                 print()
     else:
         package = args.resources or args.package

--- a/poet/templates.py
+++ b/poet/templates.py
@@ -10,6 +10,10 @@ env.filters["dash_to_studly"] = dash_to_studly
 
 
 FORMULA_TEMPLATE = env.from_string(dedent("""\
+    # typed: false
+    # frozen_string_literal: true
+
+    # Formula for {{ package.name }}
     class {{ package.name|dash_to_studly }} < Formula
       include Language::Python::Virtualenv
 

--- a/poet/test/poet_fixtures.py
+++ b/poet/test/poet_fixtures.py
@@ -92,3 +92,42 @@ old_style_pypi_json = r"""
     ]
 }
 """
+
+pipfile_lock = r"""
+{
+    "_meta": {
+        "hash": {
+            "sha256": "487983026d17b364ee5aef59eb372788015c8e6aa0f753f89a99dc185a3d1f93"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.9"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "attrs": {
+            "hashes": [
+                "sha256:149e90d6d8ac20db7a955ad60cf0e6881a3f20d37096140088356da6c716b0b1",
+                "sha256:ef6aaac3ca6cd92904cdd0d83f629a15f18053ec84e6432106f7a4d04ae4f5fb"
+            ],
+            "index": "pypi",
+            "version": "==21.2.0"
+        }
+    },
+    "develop": {}
+}
+"""
+
+pipfile_lock_stanzas = r"""
+  resource "attrs" do
+    url "https://files.pythonhosted.org/packages/ed/d6/3ebca4ca65157c12bd08a63e20ac0bdc21ac7f3694040711f9fd073c0ffb/attrs-21.2.0.tar.gz"
+    sha256 "ef6aaac3ca6cd92904cdd0d83f629a15f18053ec84e6432106f7a4d04ae4f5fb"
+  end
+"""

--- a/poet/test/test_poet.py
+++ b/poet/test/test_poet.py
@@ -41,7 +41,7 @@ def test_resources():
 
 
 def test_uses_sha256_from_json(monkeypatch):
-    monkeypatch.setenv("POET_DEBUG", 10)
+    monkeypatch.setenv("POET_DEBUG", "10")
     result = poet("pytest")
     assert b"Using provided checksum for py\n" in result
 

--- a/poet/test/test_units.py
+++ b/poet/test/test_units.py
@@ -1,9 +1,8 @@
 from __future__ import absolute_import, print_function
-
 import mock
-
+import json
 import poet
-from poet_fixtures import old_style_pypi_json
+from poet_fixtures import old_style_pypi_json, pipfile_lock, pipfile_lock_stanzas
 from testfixtures import LogCapture
 
 
@@ -17,6 +16,10 @@ class TestPoet(object):
         with LogCapture() as l:
             poet.research_package("eleven")
             assert "Fetching sdist" in str(l)
+
+    def test_generate_from_pipfile_dot_lock(self):
+        output = poet.from_lock(json.loads(pipfile_lock))
+        assert output.strip() == pipfile_lock_stanzas.strip()
 
 
 class TestUtils(object):


### PR DESCRIPTION
I'm unconventionally using a private Brew tap to deploy an internal piece of Python tooling. The problem is, generating Stanzas is a huge time sink. So much so that I actively avoid it updating dependencies. '

This PR adds the ability to interpret dependencies from a `Pipfile.lock` with a newly added option `--lock`. The `--lock` option expects a path to the directory containing the `Pipefile.lock`. Poet will take care of the rest.

I thought I fixed the build but apparently not. All tests are passing locally 🤷‍♂️ 
